### PR TITLE
JSON logging to STDOUT

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem 'uglifier', '>= 1.3.0'
 
 gem 'unicorn'
 
+gem 'logstasher', '0.6.2'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,10 @@ GEM
     i18n (0.7.0)
     json (1.8.3)
     kgio (2.9.3)
+    logstash-event (1.1.5)
+    logstasher (0.6.2)
+      logstash-event (~> 1.1.0)
+      request_store
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -87,6 +91,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.15.0)
     rake (10.4.2)
+    request_store (1.2.0)
     sass (3.4.18)
     sass-rails (5.0.3)
       railties (>= 4.0.0, < 5.0)
@@ -123,6 +128,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  logstasher (= 0.6.2)
   rails (= 4.2.4)
   sass-rails (~> 5.0)
   uglifier (>= 1.3.0)

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,4 +1,11 @@
 class RootController < ApplicationController
   def index
+    Rails.logger.info "Message via Rails.logger.info"
+    Rails.logger.warn "Message via Rails.logger.warn"
+    puts "Message via puts"
+    $stdout.puts "Message via $stdout.puts"
+    $stderr.puts "Message via $stderr.puts"
+    STDOUT.puts "Message via STDOUT.puts"
+    STDERR.puts "Message via STDERR.puts"
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,5 +72,9 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  #config.log_formatter = ::Logger::Formatter.new
+
+  config.logstasher.enabled = true
+  config.logstasher.logger = Logger.new($stdout)
+  config.logstasher.suppress_app_log = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,7 +74,9 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   #config.log_formatter = ::Logger::Formatter.new
 
+  $real_stdout = $stdout.clone
+  $stdout.reopen($stderr)
   config.logstasher.enabled = true
-  config.logstasher.logger = Logger.new($stdout)
+  config.logstasher.logger = Logger.new($real_stdout)
   config.logstasher.suppress_app_log = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,6 +53,7 @@ Rails.application.configure do
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  config.logger = ActiveSupport::TaggedLogging.new(Logger.new($stderr))
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -1,0 +1,8 @@
+if Object.const_defined?('LogStasher') && LogStasher.enabled
+  LogStasher.add_custom_fields do |fields|
+    # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
+    fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
+    # Pass request Id to logging
+    fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
+  end
+end


### PR DESCRIPTION
Use logstasher to log JSON requests to `STDOUT`. This also redirects any other `STDOUT` messages to `STDERR` so that `STDOUT` only contains JSON lines.
